### PR TITLE
Updatey things

### DIFF
--- a/src/java/edu/slu/action/ObjectAction.java
+++ b/src/java/edu/slu/action/ObjectAction.java
@@ -160,7 +160,7 @@ public class ObjectAction extends ActionSupport implements ServletRequestAware, 
     }
     
     /**
-     * Add the __rerum properties object to a given JSONObject. If __rerum already exists you need to update certain values.  See below.
+     * Add the __rerum properties object to a given JSONObject. If __rerum already exists, it will be overwritten because this method is only called on new objects.
      * Properties for consideration are:
      *   APIversion        —1.0.0
      *   history.prime     —if it has an @id, import from that, else "root"
@@ -221,7 +221,7 @@ public class ObjectAction extends ActionSupport implements ServletRequestAware, 
         else{
             if(update){
              //Hitting this means we are updating an object that did not have __rerum history.  This is weird.  What should I do?
-                //FIXME 
+                //FIXME @cubap @theHabes
             }
             else{
              //Hitting this means we are are saving an object that did not have __rerum history.  This is normal   
@@ -252,9 +252,7 @@ public class ObjectAction extends ActionSupport implements ServletRequestAware, 
     
     /**
      * Internal helper method to update the history.next property of an object.  This will occur because updateObject will create a new object from a given object, and that
-       given object will have a new next value of the new object.  Watch out for missing __rerum or malformed __rerum.history
-       * 
-       * 
+     * given object will have a new next value of the new object.  Watch out for missing __rerum or malformed __rerum.history
      * 
      * @param idForUpdate the @id of the object whose history.next needs to be updated
      * @param newNextID the @id of the newly created object to be placed in the history.next array.

--- a/src/java/edu/slu/action/ObjectAction.java
+++ b/src/java/edu/slu/action/ObjectAction.java
@@ -849,12 +849,41 @@ public class ObjectAction extends ActionSupport implements ServletRequestAware, 
         }
     }
     
-    public void setVal(){
+    private JSONObject setVal(JSONObject obj){
+        JSONObject newObjectState = new JSONObject();
+        
+        return newObjectState;
+    }
+    
+    private JSONObject unsetVal(JSONObject obj){
+        JSONObject newObjectState = new JSONObject();
+        
+        return newObjectState;
         
     }
     
-    public void unsetVal(){
-        
+    /**
+     * Public facing servlet to PATCH set or unset values of an existing RERUM object.
+     * @param  http_request The HTTP request made for the API
+     * @return JSONArray to the response out for parsing by the client application.
+     */
+    public void set(HttpServletRequest http_request)throws IOException, ServletException, Exception{
+        //TODO fix methodApproval to separate PUT and PATCH, route set and patch_update to PATCH.
+        if(null != processRequestBody(request, true) && methodApproval(request, "set")){
+            
+        }
+    }
+    
+    /**
+     * Public facing servlet to PATCH set or unset values of an existing RERUM object.
+     * @param  http_request The HTTP request made for the API
+     * @return JSONArray to the response out for parsing by the client application.
+     */
+    public void putUpdateObject(HttpServletRequest http_request)throws IOException, ServletException, Exception{
+        //TODO fix methodApproval to separate PUT and PATCH, route set and patch_update to PATCH.
+        if(null != processRequestBody(request, true) && methodApproval(request, "put_update")){
+            
+        }
     }
     
     /**
@@ -862,19 +891,15 @@ public class ObjectAction extends ActionSupport implements ServletRequestAware, 
      * This is one place new branches of an annotation may be created
      * when the `annotation.objectID` resolves to an object that has
      * an entry in .__rerum.history.next already.
-     * @param annotation.objectID
-     * @param all annotation properties include updated properties. 
-     * @ignore the following keys (they will never be updated)
-     *      @id
-     *      objectID
+     * @param http_request
      */
-    public void updateObject() throws IOException, ServletException, Exception{
+    public void patchUpdateObject(HttpServletRequest http_request) throws ServletException, Exception{
         //The client should use the If-Match header with a value of the ETag it received from the server before the editing process began, 
         //to avoid collisions of multiple users modifying the same Annotation at the same time
         //cubap: I'm not sold we have to do this. Our versioning would allow multiple changes. 
         //The application might want to throttle internally, but it can.
         Boolean historyNextUpdatePassed = false;
-        if(null!= processRequestBody(request, false) && methodApproval(request, "update")){
+        if(null!= processRequestBody(request, false) && methodApproval(request, "patch_update")){
             BasicDBObject query = new BasicDBObject();
             JSONObject received = JSONObject.fromObject(content); 
             String updateHistoryNextID = received.getString("@id");

--- a/src/java/edu/slu/action/ObjectAction.java
+++ b/src/java/edu/slu/action/ObjectAction.java
@@ -391,7 +391,7 @@ public class ObjectAction extends ActionSupport implements ServletRequestAware, 
                 if(supportStringID){
                     //We do not allow arrays of ID's for DELETE, so if it failed JSONObject parsing then this is a hard fail for DELETE.
                     //They attempted to provide a JSON object for DELETE but it was not valid JSON
-                    writeErrorResponse("The data passed was not valid JSON.  Could not get @id for DELETE: \n"+requestBody, HttpServletResponse.SC_BAD_REQUEST);
+                    writeErrorResponse("The data passed was not valid JSON.  Could not get @id: "+requestBody, HttpServletResponse.SC_BAD_REQUEST);
                     requestBody = null;
                 }
                 else{
@@ -422,7 +422,7 @@ public class ObjectAction extends ActionSupport implements ServletRequestAware, 
                         requestBody = test.getString("@id");
                         if("".equals(requestBody)){
                         //No ID provided
-                            writeErrorResponse("Must provide an id or a JSON object containing @id of object to delete.", HttpServletResponse.SC_BAD_REQUEST);
+                            writeErrorResponse("Must provide an id or a JSON object containing @id of object to perform this action.", HttpServletResponse.SC_BAD_REQUEST);
                             requestBody = null;
                         }
                         else{
@@ -967,7 +967,6 @@ public class ObjectAction extends ActionSupport implements ServletRequestAware, 
                 if(null != originalObject){
                     JSONObject newObject = JSONObject.fromObject(updatedObject);//The edited original object meant to be saved as a new object (versioning)
                     newObject = configureRerumOptions(newObject, true); //__rerum for the new object being created because of the update action
-                    //WHAT WILL THIS DO IF __rerum IS ALREADY ON THIS OBJECT?  RECREATE IT IS WHAT WE WANT.
                     newObject.remove("@id"); //This is being saved as a new object, so remove this @id for the new one to be set.
                     //Since we ignore changes to __rerum for existing objects, we do no configureRerumOptions(updatedObject);
                     DBObject dbo = (DBObject) JSON.parse(newObject.toString());

--- a/src/java/edu/slu/action/ObjectAction.java
+++ b/src/java/edu/slu/action/ObjectAction.java
@@ -253,12 +253,15 @@ public class ObjectAction extends ActionSupport implements ServletRequestAware, 
     /**
      * Internal helper method to update the history.next property of an object.  This will occur because updateObject will create a new object from a given object, and that
        given object will have a new next value of the new object.  Watch out for missing __rerum or malformed __rerum.history
+       * 
+       * 
      * 
      * @param idForUpdate the @id of the object whose history.next needs to be updated
      * @param newNextID the @id of the newly created object to be placed in the history.next array.
      * @return Boolean altered true on success, false on fail
      */
     private boolean alterHistoryNext (String idForUpdate, String newNextID){
+        //TODO @theHabes As long as we trust the objects we send to this, we can take up the lookup
         Boolean altered = false;
         BasicDBObject query = new BasicDBObject();
         query.append("@id", idForUpdate);
@@ -299,13 +302,29 @@ public class ObjectAction extends ActionSupport implements ServletRequestAware, 
         // FIXME @webanno if you notice, OPTIONS is not supported here and MUST be 
         // for Web Annotation standards compliance.  
         switch(request_type){
-            case "update":
-                if(requestMethod.equals("PUT") || requestMethod.equals("PATCH")){
+            case "put_update":
+                if(requestMethod.equals("PUT")){
                     restful = true;
                 }
                 else{
-                    writeErrorResponse("Improper request method for updating, please use PUT or PATCH.", HttpServletResponse.SC_METHOD_NOT_ALLOWED);
+                    writeErrorResponse("Improper request method for updating, please use PUT to replace this object.", HttpServletResponse.SC_METHOD_NOT_ALLOWED);
                 }
+            break;
+            case "patch_update":
+            if(requestMethod.equals("PATCH")){
+                restful = true;
+            }
+            else{
+                writeErrorResponse("Improper request method for updating, please use PATCH to alter this RERUM object.", HttpServletResponse.SC_METHOD_NOT_ALLOWED);
+            }
+            break;
+            case "set":
+            if(requestMethod.equals("PATCH")){
+                restful = true;
+            }
+            else{
+                writeErrorResponse("Improper request method for updating, PATCH to add or remove keys from this RERUM object.", HttpServletResponse.SC_METHOD_NOT_ALLOWED);
+            }
             break;
             case "create":
                 if(requestMethod.equals("POST")){
@@ -849,12 +868,20 @@ public class ObjectAction extends ActionSupport implements ServletRequestAware, 
         }
     }
     
+    /*
+        Internal method to create a key:value pair in a given JSONObject.
+        This method should only be fed reliable objects from mongo.
+    */
     private JSONObject setKey(JSONObject obj){
         JSONObject newObjectState = new JSONObject();
         
         return newObjectState;
     }
     
+    /*
+        Internal method to remove a key:value pair in a given JSONObject.
+        This method should only be fed reliable objects from mongo.
+    */
     private JSONObject unsetKey(JSONObject obj){
         JSONObject newObjectState = new JSONObject();
         
@@ -881,8 +908,62 @@ public class ObjectAction extends ActionSupport implements ServletRequestAware, 
      */
     public void putUpdateObject(HttpServletRequest http_request)throws IOException, ServletException, Exception{
         //TODO fix methodApproval to separate PUT and PATCH, route set and patch_update to PATCH.
-        if(null != processRequestBody(request, true) && methodApproval(request, "put_update")){
-            
+        //The application might want to throttle internally, but it can.
+        Boolean historyNextUpdatePassed = false;
+        if(null!= processRequestBody(request, false) && methodApproval(request, "put_update")){
+            BasicDBObject query = new BasicDBObject();
+            JSONObject received = JSONObject.fromObject(content); 
+            String updateHistoryNextID = received.getString("@id");
+            query.append("@id", updateHistoryNextID);
+            BasicDBObject originalObject = (BasicDBObject) mongoDBService.findOneByExample(Constant.COLLECTION_ANNOTATION, query); //The originalObject DB object
+            BasicDBObject updatedObject = (BasicDBObject) JSON.parse(received.toString()); //A copy of the original, this will be saved as a new object.  Make all edits to this variable.
+            boolean alreadyDeleted = checkIfDeleted(JSONObject.fromObject(originalObject));
+            if(alreadyDeleted){
+                writeErrorResponse("The object you are trying to update is deleted.", HttpServletResponse.SC_METHOD_NOT_ALLOWED);
+            }
+            else{
+                if(null != originalObject){
+                    JSONObject newObject = JSONObject.fromObject(updatedObject);//The edited original object meant to be saved as a new object (versioning)
+                    newObject = configureRerumOptions(newObject, true); //__rerum for the new object being created because of the update action
+                    //WHAT WILL THIS DO IF __rerum IS ALREADY ON THIS OBJECT?  RECREATE IT IS WHAT WE WANT.
+                    newObject.remove("@id"); //This is being saved as a new object, so remove this @id for the new one to be set.
+                    //Since we ignore changes to __rerum for existing objects, we do no configureRerumOptions(updatedObject);
+                    DBObject dbo = (DBObject) JSON.parse(newObject.toString());
+                    String newNextID = mongoDBService.save(Constant.COLLECTION_ANNOTATION, dbo);
+                    String newNextAtID = "http://devstore.rerum.io/rerumserver/id/"+newNextID;
+                    BasicDBObject dboWithObjectID = new BasicDBObject((BasicDBObject)dbo);
+                    dboWithObjectID.append("@id", newNextAtID);
+                    newObject.element("@id", newNextAtID);
+                    mongoDBService.update(Constant.COLLECTION_ANNOTATION, dbo, dboWithObjectID);
+                    historyNextUpdatePassed = alterHistoryNext(updateHistoryNextID, newNextAtID); //update history.next or original object to include the newObject @id
+                    if(historyNextUpdatePassed){
+                        JSONObject jo = new JSONObject();
+                        JSONObject iiif_validation_response = checkIIIFCompliance(newNextAtID, "2.1");
+                        jo.element("code", HttpServletResponse.SC_OK);
+                        jo.element("original_object_id", updateHistoryNextID);
+                        jo.element("new_obj_state", newObject); //FIXME: @webanno standards say this should be the response.
+                        jo.element("iiif_validation", iiif_validation_response);
+                        try {
+                            addWebAnnotationHeaders(newNextID, isContainerType(newObject), isLD(newObject));
+                            response.addHeader("Access-Control-Allow-Origin", "*");
+                            response.setStatus(HttpServletResponse.SC_OK);
+                            out = response.getWriter();
+                            out.write(mapper.writer().withDefaultPrettyPrinter().writeValueAsString(jo));
+                        } 
+                        catch (IOException ex) {
+                            Logger.getLogger(ObjectAction.class.getName()).log(Level.SEVERE, null, ex);
+                        }
+                    }
+                    else{
+                        //The error is already written to response.out, do nothing.
+                    }
+                }
+                else{
+                    //This could mean it was an external object, so we can save it as a new object (new object is root) and refer to this @id in previous.
+                    //TODO FIXME @cubap @theHabes #41
+                    writeErrorResponse("Object "+received.getString("@id")+" not found in RERUM, could not update.", HttpServletResponse.SC_BAD_REQUEST);
+                }
+            }
         }
     }
     
@@ -922,7 +1003,6 @@ public class ObjectAction extends ActionSupport implements ServletRequestAware, 
                         }
                     }
                     JSONObject newObject = JSONObject.fromObject(updatedObject);//The edited original object meant to be saved as a new object (versioning)
-
                     newObject = configureRerumOptions(newObject, true); //__rerum for the new object being created because of the update action
                     newObject.remove("@id"); //This is being saved as a new object, so remove this @id for the new one to be set.
                     //Since we ignore changes to __rerum for existing objects, we do no configureRerumOptions(updatedObject);
@@ -958,6 +1038,7 @@ public class ObjectAction extends ActionSupport implements ServletRequestAware, 
                 }
                 else{
                     //This could mean it was an external object, so we can save it as a new object (new object is root) and refer to this @id in previous.
+                    //TODO FIXME @cubap @theHabes #41
                     writeErrorResponse("Object "+received.getString("@id")+" not found in RERUM, could not update.", HttpServletResponse.SC_BAD_REQUEST);
                 }
             }

--- a/src/java/edu/slu/action/ObjectAction.java
+++ b/src/java/edu/slu/action/ObjectAction.java
@@ -849,13 +849,13 @@ public class ObjectAction extends ActionSupport implements ServletRequestAware, 
         }
     }
     
-    private JSONObject setVal(JSONObject obj){
+    private JSONObject setKey(JSONObject obj){
         JSONObject newObjectState = new JSONObject();
         
         return newObjectState;
     }
     
-    private JSONObject unsetVal(JSONObject obj){
+    private JSONObject unsetKey(JSONObject obj){
         JSONObject newObjectState = new JSONObject();
         
         return newObjectState;

--- a/src/java/struts.xml
+++ b/src/java/struts.xml
@@ -33,7 +33,7 @@
         <!-- INTERCEPTOR -->
         <interceptors>
             <interceptor name="requestServerAuthenticationFilter" class="edu.slu.filter.RequestServerAuthenticationFilter">
-                <param name="includeMethods">saveNewObject, batchSaveFromCopy, updateObject, deleteObject </param>
+                <param name="includeMethods">saveNewObject, batchSaveFromCopy, patchUpdateObject, putUpdateObject, patchSetObject, deleteObject </param>
             </interceptor>
             <interceptor name="getRequestClientInfoRecorder" class="edu.slu.filter.GetRequestClientInfoRecorder">
                 <param name="includeMethods">getbyProperties, getByID, getAllAncestors, getAllDescendants, getAllVersions</param>
@@ -59,7 +59,11 @@
         <action name="getAllAncestors" class="objectAction" method="getAllAncestors"></action>
         <action name="getAllDescendents" class="objectAction" method="getAllDescendents"></action>
         <action name="create" class="objectAction" method="saveNewObject"></action>
-        <action name="update" class="objectAction" method="updateObject"></action>
+        <!--@cubap @theHabes rewrite API to accomodate this change -->
+        <action name="patch_update" class="objectAction" method="patchUpdateObject"></action>
+        <action name="put_update" class="objectAction" method="putUpdateObject"></action>
+        <action name="set_update" class="objectAction" method="setUpdateObject"></action>
+        <!-- -->
         <action name="delete" class="objectAction" method="deleteObject"></action>
     </package>
     

--- a/src/java/struts.xml
+++ b/src/java/struts.xml
@@ -24,8 +24,35 @@
             </interceptor-stack>
         </interceptors>
         <default-interceptor-ref name="myDefault" />
-        
         <action name="getByID" class="objectAction" method="getByID"></action>
+    </package>
+    
+    <!-- This package is open to public -->
+    <package name="getAncestors" extends="default" namespace="/history">
+        <!-- INTERCEPTOR -->
+        <interceptors>
+            <interceptor name="responseEncoding" class="edu.slu.filter.ResponseEncoding"></interceptor>
+            <interceptor-stack name="myDefault">
+                <interceptor-ref name="responseEncoding" />
+                <interceptor-ref name="defaultStack" />
+            </interceptor-stack>
+        </interceptors>
+        <default-interceptor-ref name="myDefault" />
+        <action name="getAllAncestors" class="objectAction" method="getAllAncestors"></action>
+    </package>
+    
+    <!-- This package is open to public -->
+    <package name="getDescendents" extends="default" namespace="/since">
+        <!-- INTERCEPTOR -->
+        <interceptors>
+            <interceptor name="responseEncoding" class="edu.slu.filter.ResponseEncoding"></interceptor>
+            <interceptor-stack name="myDefault">
+                <interceptor-ref name="responseEncoding" />
+                <interceptor-ref name="defaultStack" />
+            </interceptor-stack>
+        </interceptors>
+        <default-interceptor-ref name="myDefault" />
+        <action name="getAllDescendents" class="objectAction" method="getAllDescendents"></action>
     </package>
     
     <!-- OBJECTS -->
@@ -36,7 +63,7 @@
                 <param name="includeMethods">saveNewObject, batchSaveFromCopy, patchUpdateObject, putUpdateObject, patchSetObject, deleteObject </param>
             </interceptor>
             <interceptor name="getRequestClientInfoRecorder" class="edu.slu.filter.GetRequestClientInfoRecorder">
-                <param name="includeMethods">getbyProperties, getByID, getAllAncestors, getAllDescendants, getAllVersions</param>
+                <param name="includeMethods">getByProperties, getByID, getAllAncestors, getAllDescendents, getAllVersions</param>
             </interceptor>
             <!--<interceptor name="responseEncoding" class="edu.slu.filter.ResponseEncoding"></interceptor>-->
             <interceptor name="inSessionFilter" class="edu.slu.filter.InSessionFilter"></interceptor>
@@ -59,7 +86,7 @@
         <action name="getAllAncestors" class="objectAction" method="getAllAncestors"></action>
         <action name="getAllDescendents" class="objectAction" method="getAllDescendents"></action>
         <action name="create" class="objectAction" method="saveNewObject"></action>
-        <!--@cubap @theHabes rewrite API to accomodate this change -->
+        <!--@cubap @theHabes rewrite API doc to accomodate this change -->
         <action name="patch_update" class="objectAction" method="patchUpdateObject"></action>
         <action name="put_update" class="objectAction" method="putUpdateObject"></action>
         <action name="set_update" class="objectAction" method="setUpdateObject"></action>

--- a/src/java/struts.xml
+++ b/src/java/struts.xml
@@ -60,7 +60,7 @@
         <!-- INTERCEPTOR -->
         <interceptors>
             <interceptor name="requestServerAuthenticationFilter" class="edu.slu.filter.RequestServerAuthenticationFilter">
-                <param name="includeMethods">saveNewObject, batchSaveFromCopy, patchUpdateObject, putUpdateObject, patchSetObject, deleteObject </param>
+                <param name="includeMethods">saveNewObject, batchSaveFromCopy, patchUpdateObject, putUpdateObject, patchSetUpdate, deleteObject </param>
             </interceptor>
             <interceptor name="getRequestClientInfoRecorder" class="edu.slu.filter.GetRequestClientInfoRecorder">
                 <param name="includeMethods">getByProperties, getByID, getAllAncestors, getAllDescendents, getAllVersions</param>
@@ -89,7 +89,7 @@
         <!--@cubap @theHabes rewrite API doc to accomodate this change -->
         <action name="patch_update" class="objectAction" method="patchUpdateObject"></action>
         <action name="put_update" class="objectAction" method="putUpdateObject"></action>
-        <action name="set_update" class="objectAction" method="setUpdateObject"></action>
+        <action name="set_update" class="objectAction" method="patchSetUpdate"></action>
         <!-- -->
         <action name="delete" class="objectAction" method="deleteObject"></action>
     </package>

--- a/web/WEB-INF/urlrewrite.xml
+++ b/web/WEB-INF/urlrewrite.xml
@@ -21,12 +21,27 @@
     
     <rule>
         <note>
-            Redirect find annotation by object id.
+            Redirect find annotation by provided object id.
         </note>
         <from>^/id/([a-z0-9]+)$</from>
         <to type="forward">/id/getByID.action?oid=$1</to>
     </rule>
-
+    
+    <rule>
+        <note>
+            Redirect find descendant branch from provided object id.
+        </note>
+        <from>^/since/([a-z0-9]+)$</from>
+        <to type="forward">/since/getAllDescendents.action?oid=$1</to>
+    </rule>
+    
+    <rule>
+        <note>
+            Redirect find ancestoral branch from provided object id.
+        </note>
+        <from>^/history/([a-z0-9]+)$</from>
+        <to type="forward">/history/getAllAncestors.action?oid=$1</to>
+    </rule>
 
     <outbound-rule>
         <note>


### PR DESCRIPTION
APIs with graceful failing and proper REST implementation for
PUT update
PATCH update
PATCH set

History getters' API with graceful failing and proper REST implementation.  Since these are GETs, we had to create special URI's for them to pass the data along the API needs to know to perform the algorithms.
/history/oid
/since/oid

Tested and everything seems to work.  Feel free to test yourself.  My test root obj has a spoiled history tree from testing the various updates so unfortunately you will need to make a fresh one to test with @cubap.  