### PR TITLE
Healthy Trees

### DIFF
--- a/src/java/edu/slu/action/ObjectAction.java
+++ b/src/java/edu/slu/action/ObjectAction.java
@@ -714,7 +714,6 @@ public class ObjectAction extends ActionSupport implements ServletRequestAware, 
                 }
             break;
             case "delete":
-                System.out.println("Method delete detected");
                 auth_verified =  verifyAccess(access_token);
                 if(auth_verified){
                     if(requestMethod.equals("DELETE")){
@@ -2665,7 +2664,7 @@ public class ObjectAction extends ActionSupport implements ServletRequestAware, 
             JWTVerifier verifier = JWT.require(algorithm).build(); //Reusable verifier instance
                //.withIssuer("auth0")
             generatorID = receivedToken.getClaim(Constant.RERUM_AGENT_ClAIM).asString();
-            System.out.println("Generator id from key "+generatorID);
+           //System.out.println("Generator id from key "+generatorID);
             if(botCheck(generatorID)){
                 System.out.println("It passed the bot check, no need to verify the access token.  I have the generator ID.  ");
                 verified = true;
@@ -2715,7 +2714,7 @@ public class ObjectAction extends ActionSupport implements ServletRequestAware, 
                 verified = false;
             }
         }
-        System.out.println("I need a generator out of all this.  Did I get it: "+generatorID);
+        System.out.println("Generator Verified: "+generatorID);
         return verified;
     }
     

--- a/src/java/edu/slu/action/ObjectAction.java
+++ b/src/java/edu/slu/action/ObjectAction.java
@@ -2298,12 +2298,13 @@ public class ObjectAction extends ActionSupport implements ServletRequestAware, 
                     //Strictly, all history trees must have num(root) > 0.  
                     fixHistory.getJSONObject("__rerum").getJSONObject("history").element("prime", "root");
                     try {
-                        //Its descendants need to know it is a root (change their prime).
+                        //Its descendants need to know this is now a root (change their prime).
                         success = newTreePrime(fixHistory);
                     } catch (Exception ex) {
                         System.out.println("Could not update all descendants with their new prime value");
                         previous_id = ""; //A hack to make sure we do not process the history.previous b/c there was an error.
-                        success = false;
+                        success = false; //This is an error
+                        break; //Stop updating things, there has been an error.  This history.next[i] object cannot be considered prime.
                     }
                 }
                 else if(!previous_id.equals("")){ //The object being deleted had a previous.  That is now absorbed by this next object to mend the gap.  
@@ -2316,12 +2317,9 @@ public class ObjectAction extends ActionSupport implements ServletRequestAware, 
                     // theHabes: Are their bad implications on the relevant nodes in the tree that reference this one if we allow it to delete?  Will their account of the history be correct?
                     //success = false;
                 }
-                if(success){
-                    //Do not update this object if newTreePrime(fixHistory) failed!
-                    Object forMongo = JSON.parse(fixHistory.toString()); //JSONObject cannot be converted to BasicDBObject
-                    objWithUpdate = (BasicDBObject)forMongo;
-                    mongoDBService.update(Constant.COLLECTION_ANNOTATION, objToUpdate, objWithUpdate);
-                }
+                Object forMongo = JSON.parse(fixHistory.toString()); //JSONObject cannot be converted to BasicDBObject
+                objWithUpdate = (BasicDBObject)forMongo;
+                mongoDBService.update(Constant.COLLECTION_ANNOTATION, objToUpdate, objWithUpdate);
              }
              else{
                 System.out.println("Cannot find object associated with the history.next[i] URI.  It is not in the RERUM database.  URI:"+nextID);

--- a/src/java/edu/slu/action/ObjectAction.java
+++ b/src/java/edu/slu/action/ObjectAction.java
@@ -2298,8 +2298,10 @@ public class ObjectAction extends ActionSupport implements ServletRequestAware, 
                     //Strictly, all history trees must have num(root) > 0.  
                     fixHistory.getJSONObject("__rerum").getJSONObject("history").element("prime", "root");
                     try {
+                        //Its descendants need to know it is a root (change their prime).
                         success = newTreePrime(fixHistory);
                     } catch (Exception ex) {
+                        System.out.println("Could not update all descendants with their new prime value");
                         previous_id = ""; //A hack to make sure we do not process the history.previous b/c there was an error.
                         success = false;
                     }
@@ -2314,9 +2316,12 @@ public class ObjectAction extends ActionSupport implements ServletRequestAware, 
                     // theHabes: Are their bad implications on the relevant nodes in the tree that reference this one if we allow it to delete?  Will their account of the history be correct?
                     //success = false;
                 }
-                Object forMongo = JSON.parse(fixHistory.toString()); //JSONObject cannot be converted to BasicDBObject
-                objWithUpdate = (BasicDBObject)forMongo;
-                mongoDBService.update(Constant.COLLECTION_ANNOTATION, objToUpdate, objWithUpdate);
+                if(success){
+                    //Do not update this object if newTreePrime(fixHistory) failed!
+                    Object forMongo = JSON.parse(fixHistory.toString()); //JSONObject cannot be converted to BasicDBObject
+                    objWithUpdate = (BasicDBObject)forMongo;
+                    mongoDBService.update(Constant.COLLECTION_ANNOTATION, objToUpdate, objWithUpdate);
+                }
              }
              else{
                 System.out.println("Cannot find object associated with the history.next[i] URI.  It is not in the RERUM database.  URI:"+nextID);

--- a/src/java/edu/slu/action/ObjectAction.java
+++ b/src/java/edu/slu/action/ObjectAction.java
@@ -2307,14 +2307,14 @@ public class ObjectAction extends ActionSupport implements ServletRequestAware, 
                  //The history.next[i] object could not be found in this RERUM Database.  
                 if(nextID.contains(Constant.RERUM_PREFIX)){
                     //It has this APIs id pattern, that means we expected to find it.  This is an error, break out of the function with false.
-                    System.out.println("Cannot find object associated with the history.next[i] value in RERUM Database.  URI:"+nextID);
+                    System.out.println("Cannot find object associated with the history.next[i] URI.  It is not in the RERUM database.  URI:"+nextID);
                     success = false;
                     detectedPrevious = false; // A cheap hack to avoid looking to history.previous
                     break;
                 }
                 else{
                     //The history.next[i] object is an external object.  It does not have history, just move past it and continue the loop.
-                    System.out.println("The value of a next history node was an external ID.  Nothing to heal.  URI:"+nextID);
+                    System.out.println("The value of a history.next[i] was an external URI.  Nothing to heal.  URI:"+nextID);
                     continue;
                 }
              }
@@ -2346,12 +2346,13 @@ public class ObjectAction extends ActionSupport implements ServletRequestAware, 
              else{
                 //The history.previous object could not be found in this RERUM Database.  
                 if(previous_id.contains(Constant.RERUM_PREFIX)){
-                    System.out.println("Cannot find object in RERUM Database.  URI:"+previous_id);
+                    //It has this APIs id pattern, that means we expected to find it.  This is an error, break out of the function with false.
+                    System.out.println("Cannot find object associated with the history.previous URI.  It is not in the RERUM database.  URI:"+previous_id);
                     success = false;
                 }
                 else{
                     //The history.previous is an external object.  It does not have history, the buck stops here and that's OK.
-                    System.out.println("The value of a previous history node was an external ID.  Nothing to heal  URI:"+previous_id);
+                    System.out.println("The value of history.previous was an external URI.  Nothing to heal.  URI:"+previous_id);
                     success = true;
                 }
             }

--- a/src/java/edu/slu/action/ObjectAction.java
+++ b/src/java/edu/slu/action/ObjectAction.java
@@ -358,7 +358,7 @@ public class ObjectAction extends ActionSupport implements ServletRequestAware, 
      * @param update A trigger for special handling from update actions
      * @return configuredObject The same object that was recieved but with the proper __rerum options.  This object is intended to be saved as a new object (@see versioning)
      */
-    public JSONObject configureRerumOptions(JSONObject received, boolean update){
+    public JSONObject configureRerumOptions(JSONObject received, boolean update, boolean extUpdate){
         JSONObject configuredObject = received;
         JSONObject received_options;
         try{
@@ -386,47 +386,56 @@ public class ObjectAction extends ActionSupport implements ServletRequestAware, 
         rerumOptions.element("createdAt", formattedCreationDateTime);
         rerumOptions.element("isOverwritten", "");
         rerumOptions.element("isReleased", "");
-        if(received_options.containsKey("history")){
-            history = received_options.getJSONObject("history");
-            if(update){
-                //This means we are configuring from the update action and we have passed in a clone of the originating object (with its @id) that contained a __rerum.history
-                if(history.getString("prime").equals("root")){
-                    //Hitting this case means we are updating from the prime object, so we can't pass "root" on as the prime value
-                    history_prime = received.getString("@id");
+        if(extUpdate){
+            //We are "importing" an external object as a new object in RERUM.  It can knows its previous external self, but is a root for its existence in RERUM.
+            received_options = new JSONObject();
+            history_prime = "root";
+            if(received.containsKey("@id")){
+                history_previous = received.getString("@id");
+            }
+            else if(received.containsKey("id")){
+                history_previous = received.getString("id");
+            }
+            else{
+                history_previous = "";
+            }
+        }
+        else{
+            //We are either updating an existing RERUM object or creating a new one.
+            if(received_options.containsKey("history")){
+                history = received_options.getJSONObject("history");
+                if(update){
+                    //This means we are configuring from the update action and we have passed in a clone of the originating object (with its @id) that contained a __rerum.history
+                    if(history.getString("prime").equals("root")){
+                        //Hitting this case means we are updating from the prime object, so we can't pass "root" on as the prime value
+                        history_prime = received.getString("@id");
+                    }
+                    else{
+                        //Hitting this means we are updating an object that already knows its prime, so we can pass on the prime value
+                        history_prime = history.getString("prime");
+                    }
+                    //Either way, we know the previous value shold be the @id of the object received here. 
+                    history_previous = received.getString("@id");
                 }
                 else{
-                    //Hitting this means we are updating an object that already knows its prime, so we can pass on the prime value
-                    history_prime = history.getString("prime");
+                    //Hitting this means we are saving a new object and found that __rerum.history existed.  We don't trust it, act like it doesn't have it.
+                    history_prime = "root";
+                    history_previous = "";
                 }
-                //Either way, we know the previous value shold be the @id of the object received here. 
-                history_previous = received.getString("@id");
             }
             else{
-                //Hitting this means we are saving a new object and found that __rerum.history existed.  We don't trust it.
+                //Hitting this means we are are saving an object that did not have __rerum history.  This is normal   
                 history_prime = "root";
                 history_previous = "";
             }
-        }
-        else{
-            if(update){
-             //Hitting this means we are updating an object that did not have __rerum history.  This is an external object update.
-                //FIXME @cubap @theHabes
-                history_prime = "root";
-                history_previous = received.getString("@id");
+            if(received_options.containsKey("releases")){
+                releases = received_options.getJSONObject("releases");
+                releases_previous = releases.getString("previous");
             }
             else{
-             //Hitting this means we are are saving an object that did not have __rerum history.  This is normal   
-                history_prime = "root";
-                history_previous = "";
+                releases_previous = "";         
             }
-        }
-        if(received_options.containsKey("releases")){
-            releases = received_options.getJSONObject("releases");
-            releases_previous = releases.getString("previous");
-        }
-        else{
-            releases_previous = "";         
-        }
+        } 
         releases.element("next", emptyArray);
         history.element("next", emptyArray);
         history.element("previous", history_previous);
@@ -1352,7 +1361,7 @@ public class ObjectAction extends ActionSupport implements ServletRequestAware, 
             JSONArray received_array = JSONArray.fromObject(content);
             for(int b=0; b<received_array.size(); b++){ //Configure __rerum on each object
                 JSONObject configureMe = received_array.getJSONObject(b);
-                configureMe = configureRerumOptions(configureMe, false); //configure this object
+                configureMe = configureRerumOptions(configureMe, false, false); //configure this object
                 
                 received_array.set(b, configureMe); //Replace the current iterated object in the array with the configured object
             }
@@ -1402,7 +1411,7 @@ public class ObjectAction extends ActionSupport implements ServletRequestAware, 
             }
             else{
                 JSONObject iiif_validation_response = checkIIIFCompliance(received, true); //This boolean should be provided by the user somehow.  It is a intended-to-be-iiif flag
-                received = configureRerumOptions(received, false);
+                received = configureRerumOptions(received, false, false);
                 received.remove("_id");
                 DBObject dbo = (DBObject) JSON.parse(received.toString());
                 if(null!=request.getHeader("Slug")){
@@ -1481,7 +1490,7 @@ public class ObjectAction extends ActionSupport implements ServletRequestAware, 
                         }
                         if(updateCount > 0){
                             JSONObject newObject = JSONObject.fromObject(updatedObject);//The edited original object meant to be saved as a new object (versioning)
-                            newObject = configureRerumOptions(newObject, true); //__rerum for the new object being created because of the update action
+                            newObject = configureRerumOptions(newObject, true, false); //__rerum for the new object being created because of the update action
                             newObject.remove("@id"); //This is being saved as a new object, so remove this @id for the new one to be set.
                             //Since we ignore changes to __rerum for existing objects, we do no configureRerumOptions(updatedObject);
                             DBObject dbo = (DBObject) JSON.parse(newObject.toString());
@@ -1587,7 +1596,7 @@ public class ObjectAction extends ActionSupport implements ServletRequestAware, 
                         }
                         if(updateCount > 0){
                             JSONObject newObject = JSONObject.fromObject(updatedObject);//The edited original object meant to be saved as a new object (versioning)
-                            newObject = configureRerumOptions(newObject, true); //__rerum for the new object being created because of the update action
+                            newObject = configureRerumOptions(newObject, true, false); //__rerum for the new object being created because of the update action
                             newObject.remove("@id"); //This is being saved as a new object, so remove this @id for the new one to be set.
                             //Since we ignore changes to __rerum for existing objects, we do no configureRerumOptions(updatedObject);
                             DBObject dbo = (DBObject) JSON.parse(newObject.toString());
@@ -1698,7 +1707,7 @@ public class ObjectAction extends ActionSupport implements ServletRequestAware, 
                         }
                         else{
                             JSONObject newObject = JSONObject.fromObject(updatedObject);//The edited original object meant to be saved as a new object (versioning)
-                            newObject = configureRerumOptions(newObject, true); //__rerum for the new object being created because of the update action
+                            newObject = configureRerumOptions(newObject, true, false); //__rerum for the new object being created because of the update action
                             newObject.remove("@id"); //This is being saved as a new object, so remove this @id for the new one to be set.
                             //Since we ignore changes to __rerum for existing objects, we do no configureRerumOptions(updatedObject);
                             DBObject dbo = (DBObject) JSON.parse(newObject.toString());
@@ -1783,7 +1792,7 @@ public class ObjectAction extends ActionSupport implements ServletRequestAware, 
                         JSONObject originalProperties = originalJSONObj.getJSONObject("__rerum");
                         newObject.element("__rerum", originalProperties);
                         //Since this is a put update, it is possible __rerum is not in the object provided by the user.  We get a reliable copy oof the original out of mongo
-                        newObject = configureRerumOptions(newObject, true); //__rerum for the new object being created because of the update action
+                        newObject = configureRerumOptions(newObject, true, false); //__rerum for the new object being created because of the update action
                         newObject.remove("@id"); //This is being saved as a new object, so remove this @id for the new one to be set.
                         newObject.remove("_id");
                         DBObject dbo = (DBObject) JSON.parse(newObject.toString());
@@ -2273,7 +2282,7 @@ public class ObjectAction extends ActionSupport implements ServletRequestAware, 
             next_ids = new JSONArray(); //This ensures the loop below does not run.
             success = false; //This will bubble out to deleteObj() and have the side effect that this object is not deleted.  @see treeHealed
          }
-         boolean isRoot = prime_id.equals("root"); 
+         boolean objToDeleteisRoot = prime_id.equals("root"); 
          //Update the history.previous of all the next ids in the array of the deleted object
          for(int n=0; n<next_ids.size(); n++){
              BasicDBObject query = new BasicDBObject();
@@ -2284,8 +2293,8 @@ public class ObjectAction extends ActionSupport implements ServletRequestAware, 
              objToUpdate = (BasicDBObject) mongoDBService.findOneByExample(Constant.COLLECTION_ANNOTATION, query); 
              if(null != objToUpdate){
                 JSONObject fixHistory = JSONObject.fromObject(objToUpdate);
-                if(isRoot){ 
-                    //The object being deleted was root.  That means these next objects must become root.  Their descendants need to know their new root.  
+                if(objToDeleteisRoot){ 
+                    //The object being deleted is root.  That means this next object must become root. 
                     //Strictly, all history trees must have num(root) > 0.  
                     fixHistory.getJSONObject("__rerum").getJSONObject("history").element("prime", "root");
                     try {
@@ -2490,7 +2499,7 @@ public class ObjectAction extends ActionSupport implements ServletRequestAware, 
         try {
             JSONObject jo = new JSONObject();
             JSONObject iiif_validation_response = checkIIIFCompliance(externalObj, true);
-            JSONObject newObjState = configureRerumOptions(externalObj, true);
+            JSONObject newObjState = configureRerumOptions(externalObj, false, true);
             DBObject dbo = (DBObject) JSON.parse(newObjState.toString());
             String exernalObjID = newObjState.getString("@id");
             String newRootID;
@@ -2501,8 +2510,6 @@ public class ObjectAction extends ActionSupport implements ServletRequestAware, 
             dboWithObjectID.append("@id", newRootID);
             newObjState.element("@id", newRootID);
             mongoDBService.update(Constant.COLLECTION_ANNOTATION, dbo, dboWithObjectID);
-            newObjState = configureRerumOptions(newObjState, false);
-            newObjState = alterHistoryPrevious(newObjState, exernalObjID); //update history.previous of the new object to contain the external object's @id.
             expandPrivateRerumProperty(newObjState);
             newObjState.remove("_id");
             jo.element("code", HttpServletResponse.SC_CREATED);

--- a/src/java/edu/slu/action/ObjectAction.java
+++ b/src/java/edu/slu/action/ObjectAction.java
@@ -2296,12 +2296,12 @@ public class ObjectAction extends ActionSupport implements ServletRequestAware, 
                 if(objToDeleteisRoot){ 
                     //The object being deleted is root.  That means this next object must become root. 
                     //Strictly, all history trees must have num(root) > 0.  
-                    fixHistory.getJSONObject("__rerum").getJSONObject("history").element("prime", "root");
-                    fixHistory.getJSONObject("__rerum").getJSONObject("history").element("previous", ""); //The previous is deleted, so forget about it
                     try {
                         //Its descendants need to know this is now a root (change their prime).
                         System.out.println("I am deleteing a root object.  Lets do newTreePrime()");
                         success = newTreePrime(fixHistory);
+                        fixHistory.getJSONObject("__rerum").getJSONObject("history").element("prime", "root");
+                        fixHistory.getJSONObject("__rerum").getJSONObject("history").element("previous", ""); //The previous is deleted, so forget about it
                     } catch (Exception ex) {
                         System.out.println("Could not update all descendants with their new prime value");
                         previous_id = ""; //A hack to make sure we do not process the history.previous b/c there was an error.
@@ -2367,7 +2367,7 @@ public class ObjectAction extends ActionSupport implements ServletRequestAware, 
          }
          else{
             //The history.previous is an external object.  It does not have history, the buck stops here and that's OK.
-            System.out.println("The value of history.previous was an external URI.  Nothing to heal.  URI:"+previous_id); 
+            System.out.println("The value of history.previous was an external URI or was not present.  Nothing to heal.  URI:"+previous_id); 
          }
          return success;
      }
@@ -2383,6 +2383,7 @@ public class ObjectAction extends ActionSupport implements ServletRequestAware, 
          try{
             String primeID = obj.getString("@id");
             List<DBObject> ls_versions = getAllVersions(obj);
+            System.out.println("There are "+ls_versions.size()+" nodes in history");
             JSONArray descendants = getAllDescendants(ls_versions, obj, new JSONArray());
             System.out.println("There are "+descendants.size()+" descendants to update.");
             for(int n=0; n< descendants.size(); n++){

--- a/src/java/edu/slu/action/ObjectAction.java
+++ b/src/java/edu/slu/action/ObjectAction.java
@@ -2314,7 +2314,7 @@ public class ObjectAction extends ActionSupport implements ServletRequestAware, 
                 }
                 else{
                     //The history.next[i] object is an external object.  It does not have history, just move past it and continue the loop.
-                    System.out.println("The value of a vext history node was an external ID.  Nothing to heal.  URI:"+nextID);
+                    System.out.println("The value of a next history node was an external ID.  Nothing to heal.  URI:"+nextID);
                     continue;
                 }
              }

--- a/src/java/edu/slu/action/ObjectAction.java
+++ b/src/java/edu/slu/action/ObjectAction.java
@@ -2304,9 +2304,19 @@ public class ObjectAction extends ActionSupport implements ServletRequestAware, 
                 mongoDBService.update(Constant.COLLECTION_ANNOTATION, objToUpdate, objWithUpdate);
              }
              else{
-                 System.out.println("could not find an object assosiated with id found in history tree");
-                 success = false;
-                 //Yikes this is an error, could not find an object assosiated with id found in history tree.
+                 //The history.next[i] object could not be found in this RERUM Database.  
+                if(nextID.contains(Constant.RERUM_PREFIX)){
+                    //It has this APIs id pattern, that means we expected to find it.  This is an error, break out of the function with false.
+                    System.out.println("Cannot find object associated with the history.next[i] value in RERUM Database.  URI:"+nextID);
+                    success = false;
+                    detectedPrevious = false; // A cheap hack to avoid looking to history.previous
+                    break;
+                }
+                else{
+                    //The history.next[i] object is an external object.  It does not have history, just move past it and continue the loop.
+                    System.out.println("The value of a vext history node was an external ID.  Nothing to heal.  URI:"+nextID);
+                    continue;
+                }
              }
          }
          if(detectedPrevious){ 
@@ -2334,10 +2344,17 @@ public class ObjectAction extends ActionSupport implements ServletRequestAware, 
                 mongoDBService.update(Constant.COLLECTION_ANNOTATION, objToUpdate2, objWithUpdate2);
              }
              else{
-                 //Yikes this is an error.  We had a previous id in the object but could not find it in the store.
-                 System.out.println("We had a previous id in the object but could not find it in the store");
-                 success = false;
-             }
+                //The history.previous object could not be found in this RERUM Database.  
+                if(previous_id.contains(Constant.RERUM_PREFIX)){
+                    System.out.println("Cannot find object in RERUM Database.  URI:"+previous_id);
+                    success = false;
+                }
+                else{
+                    //The history.previous is an external object.  It does not have history, the buck stops here and that's OK.
+                    System.out.println("The value of a previous history node was an external ID.  Nothing to heal  URI:"+previous_id);
+                    success = true;
+                }
+            }
          }
          return success;
      }

--- a/src/java/edu/slu/action/ObjectAction.java
+++ b/src/java/edu/slu/action/ObjectAction.java
@@ -2300,7 +2300,8 @@ public class ObjectAction extends ActionSupport implements ServletRequestAware, 
                         //Its descendants need to know this is now a root (change their prime).
                         success = newTreePrime(fixHistory);
                         fixHistory.getJSONObject("__rerum").getJSONObject("history").element("prime", "root");
-                        fixHistory.getJSONObject("__rerum").getJSONObject("history").element("previous", previous_id); //The previous is deleted, so forget about it
+                        //The previous alwats inherited in this case, even if it isn't there.
+                        fixHistory.getJSONObject("__rerum").getJSONObject("history").element("previous", previous_id); 
                     } catch (Exception ex) {
                         System.out.println("Could not update all descendants with their new prime value");
                         previous_id = ""; //A hack to make sure we do not process the history.previous b/c there was an error.
@@ -2384,7 +2385,7 @@ public class ObjectAction extends ActionSupport implements ServletRequestAware, 
             for(int n=0; n< descendants.size(); n++){
                 JSONObject descendantForUpdate = descendants.getJSONObject(n);
                 JSONObject originalDescendant = descendants.getJSONObject(n);
-                BasicDBObject objToUpdate = (BasicDBObject)JSON.parse(originalDescendant.toString());;
+                BasicDBObject objToUpdate = (BasicDBObject)JSON.parse(originalDescendant.toString());
                 descendantForUpdate.getJSONObject("__rerum").getJSONObject("history").element("prime", primeID);
                 BasicDBObject objWithUpdate = (BasicDBObject)JSON.parse(descendantForUpdate.toString());
                 mongoDBService.update(Constant.COLLECTION_ANNOTATION, objToUpdate, objWithUpdate);

--- a/src/java/edu/slu/action/ObjectAction.java
+++ b/src/java/edu/slu/action/ObjectAction.java
@@ -1,4 +1,4 @@
-/*
+ /*
  * To change this license header, choose License Headers in Project Properties.
  * To change this template file, choose Tools | Templates
  * and open the template in the editor.
@@ -15,7 +15,6 @@
     * to request that the origin server accept the entity enclosed in the request
     * as a new subordinate of the resource identified by the Request-URI 
     * in the Request-Line.
-
  * PUT
     * HTTP.PUT can be used when the client is sending data to the the server and
     * the client is determining the URI for the newly created resource. The PUT method 
@@ -28,7 +27,6 @@
     * It is most-often utilized for update capabilities, PUT-ing to a known resource
     * URI with the request body containing the newly-updated representation of the 
     * original resource.
-
  * PATCH
     * HTTP.PATCH can be used when the client is sending one or more changes to be
     * applied by the the server. The PATCH method requests that a set of changes described 
@@ -110,7 +108,6 @@ import javax.servlet.ServletInputStream;
  * @author hanyan &&  bhaberbe
  All the actions hit as an API like ex. /saveNewObject.action
  This implementation follows RESTFUL standards.  If you make changes, please adhere to this standard.
-
  */
 public class ObjectAction extends ActionSupport implements ServletRequestAware, ServletResponseAware{
     private String content;
@@ -358,7 +355,7 @@ public class ObjectAction extends ActionSupport implements ServletRequestAware, 
      * @param update A trigger for special handling from update actions
      * @return configuredObject The same object that was recieved but with the proper __rerum options.  This object is intended to be saved as a new object (@see versioning)
      */
-    public JSONObject configureRerumOptions(JSONObject received, boolean update, boolean extUpdate){
+    public JSONObject configureRerumOptions(JSONObject received, boolean update){
         JSONObject configuredObject = received;
         JSONObject received_options;
         try{
@@ -386,56 +383,47 @@ public class ObjectAction extends ActionSupport implements ServletRequestAware, 
         rerumOptions.element("createdAt", formattedCreationDateTime);
         rerumOptions.element("isOverwritten", "");
         rerumOptions.element("isReleased", "");
-        if(extUpdate){
-            //We are "importing" an external object as a new object in RERUM.  It can knows its previous external self, but is a root for its existence in RERUM.
-            received_options = new JSONObject();
-            history_prime = "root";
-            if(received.containsKey("@id")){
+        if(received_options.containsKey("history")){
+            history = received_options.getJSONObject("history");
+            if(update){
+                //This means we are configuring from the update action and we have passed in a clone of the originating object (with its @id) that contained a __rerum.history
+                if(history.getString("prime").equals("root")){
+                    //Hitting this case means we are updating from the prime object, so we can't pass "root" on as the prime value
+                    history_prime = received.getString("@id");
+                }
+                else{
+                    //Hitting this means we are updating an object that already knows its prime, so we can pass on the prime value
+                    history_prime = history.getString("prime");
+                }
+                //Either way, we know the previous value shold be the @id of the object received here. 
                 history_previous = received.getString("@id");
             }
-            else if(received.containsKey("id")){
-                history_previous = received.getString("id");
-            }
             else{
+                //Hitting this means we are saving a new object and found that __rerum.history existed.  We don't trust it.
+                history_prime = "root";
                 history_previous = "";
             }
         }
         else{
-            //We are either updating an existing RERUM object or creating a new one.
-            if(received_options.containsKey("history")){
-                history = received_options.getJSONObject("history");
-                if(update){
-                    //This means we are configuring from the update action and we have passed in a clone of the originating object (with its @id) that contained a __rerum.history
-                    if(history.getString("prime").equals("root")){
-                        //Hitting this case means we are updating from the prime object, so we can't pass "root" on as the prime value
-                        history_prime = received.getString("@id");
-                    }
-                    else{
-                        //Hitting this means we are updating an object that already knows its prime, so we can pass on the prime value
-                        history_prime = history.getString("prime");
-                    }
-                    //Either way, we know the previous value shold be the @id of the object received here. 
-                    history_previous = received.getString("@id");
-                }
-                else{
-                    //Hitting this means we are saving a new object and found that __rerum.history existed.  We don't trust it, act like it doesn't have it.
-                    history_prime = "root";
-                    history_previous = "";
-                }
+            if(update){
+             //Hitting this means we are updating an object that did not have __rerum history.  This is an external object update.
+                //FIXME @cubap @theHabes
+                history_prime = "root";
+                history_previous = received.getString("@id");
             }
             else{
-                //Hitting this means we are are saving an object that did not have __rerum history.  This is normal   
+             //Hitting this means we are are saving an object that did not have __rerum history.  This is normal   
                 history_prime = "root";
                 history_previous = "";
             }
-            if(received_options.containsKey("releases")){
-                releases = received_options.getJSONObject("releases");
-                releases_previous = releases.getString("previous");
-            }
-            else{
-                releases_previous = "";         
-            }
-        } 
+        }
+        if(received_options.containsKey("releases")){
+            releases = received_options.getJSONObject("releases");
+            releases_previous = releases.getString("previous");
+        }
+        else{
+            releases_previous = "";         
+        }
         releases.element("next", emptyArray);
         history.element("next", emptyArray);
         history.element("previous", history_previous);
@@ -1361,7 +1349,7 @@ public class ObjectAction extends ActionSupport implements ServletRequestAware, 
             JSONArray received_array = JSONArray.fromObject(content);
             for(int b=0; b<received_array.size(); b++){ //Configure __rerum on each object
                 JSONObject configureMe = received_array.getJSONObject(b);
-                configureMe = configureRerumOptions(configureMe, false, false); //configure this object
+                configureMe = configureRerumOptions(configureMe, false); //configure this object
                 
                 received_array.set(b, configureMe); //Replace the current iterated object in the array with the configured object
             }
@@ -1411,7 +1399,7 @@ public class ObjectAction extends ActionSupport implements ServletRequestAware, 
             }
             else{
                 JSONObject iiif_validation_response = checkIIIFCompliance(received, true); //This boolean should be provided by the user somehow.  It is a intended-to-be-iiif flag
-                received = configureRerumOptions(received, false, false);
+                received = configureRerumOptions(received, false);
                 received.remove("_id");
                 DBObject dbo = (DBObject) JSON.parse(received.toString());
                 if(null!=request.getHeader("Slug")){
@@ -1490,7 +1478,7 @@ public class ObjectAction extends ActionSupport implements ServletRequestAware, 
                         }
                         if(updateCount > 0){
                             JSONObject newObject = JSONObject.fromObject(updatedObject);//The edited original object meant to be saved as a new object (versioning)
-                            newObject = configureRerumOptions(newObject, true, false); //__rerum for the new object being created because of the update action
+                            newObject = configureRerumOptions(newObject, true); //__rerum for the new object being created because of the update action
                             newObject.remove("@id"); //This is being saved as a new object, so remove this @id for the new one to be set.
                             //Since we ignore changes to __rerum for existing objects, we do no configureRerumOptions(updatedObject);
                             DBObject dbo = (DBObject) JSON.parse(newObject.toString());
@@ -1596,7 +1584,7 @@ public class ObjectAction extends ActionSupport implements ServletRequestAware, 
                         }
                         if(updateCount > 0){
                             JSONObject newObject = JSONObject.fromObject(updatedObject);//The edited original object meant to be saved as a new object (versioning)
-                            newObject = configureRerumOptions(newObject, true, false); //__rerum for the new object being created because of the update action
+                            newObject = configureRerumOptions(newObject, true); //__rerum for the new object being created because of the update action
                             newObject.remove("@id"); //This is being saved as a new object, so remove this @id for the new one to be set.
                             //Since we ignore changes to __rerum for existing objects, we do no configureRerumOptions(updatedObject);
                             DBObject dbo = (DBObject) JSON.parse(newObject.toString());
@@ -1707,7 +1695,7 @@ public class ObjectAction extends ActionSupport implements ServletRequestAware, 
                         }
                         else{
                             JSONObject newObject = JSONObject.fromObject(updatedObject);//The edited original object meant to be saved as a new object (versioning)
-                            newObject = configureRerumOptions(newObject, true, false); //__rerum for the new object being created because of the update action
+                            newObject = configureRerumOptions(newObject, true); //__rerum for the new object being created because of the update action
                             newObject.remove("@id"); //This is being saved as a new object, so remove this @id for the new one to be set.
                             //Since we ignore changes to __rerum for existing objects, we do no configureRerumOptions(updatedObject);
                             DBObject dbo = (DBObject) JSON.parse(newObject.toString());
@@ -1792,7 +1780,7 @@ public class ObjectAction extends ActionSupport implements ServletRequestAware, 
                         JSONObject originalProperties = originalJSONObj.getJSONObject("__rerum");
                         newObject.element("__rerum", originalProperties);
                         //Since this is a put update, it is possible __rerum is not in the object provided by the user.  We get a reliable copy oof the original out of mongo
-                        newObject = configureRerumOptions(newObject, true, false); //__rerum for the new object being created because of the update action
+                        newObject = configureRerumOptions(newObject, true); //__rerum for the new object being created because of the update action
                         newObject.remove("@id"); //This is being saved as a new object, so remove this @id for the new one to be set.
                         newObject.remove("_id");
                         DBObject dbo = (DBObject) JSON.parse(newObject.toString());
@@ -2282,7 +2270,7 @@ public class ObjectAction extends ActionSupport implements ServletRequestAware, 
             next_ids = new JSONArray(); //This ensures the loop below does not run.
             success = false; //This will bubble out to deleteObj() and have the side effect that this object is not deleted.  @see treeHealed
          }
-         boolean objToDeleteisRoot = prime_id.equals("root"); 
+         boolean isRoot = prime_id.equals("root"); 
          //Update the history.previous of all the next ids in the array of the deleted object
          for(int n=0; n<next_ids.size(); n++){
              BasicDBObject query = new BasicDBObject();
@@ -2293,19 +2281,9 @@ public class ObjectAction extends ActionSupport implements ServletRequestAware, 
              objToUpdate = (BasicDBObject) mongoDBService.findOneByExample(Constant.COLLECTION_ANNOTATION, query); 
              if(null != objToUpdate){
                 JSONObject fixHistory = JSONObject.fromObject(objToUpdate);
-                if(objToDeleteisRoot){ 
-                    //The object being deleted is root.  That means this next object must become root. 
-                    //Strictly, all history trees must have num(root) > 0.  
+                if(isRoot){ //The object being deleted was root.  That means these next objects must become root.  Strictly, all history trees must have num(root) > 0.  
                     fixHistory.getJSONObject("__rerum").getJSONObject("history").element("prime", "root");
-                    try {
-                        //Its descendants need to know this is now a root (change their prime).
-                        success = newTreePrime(fixHistory);
-                    } catch (Exception ex) {
-                        System.out.println("Could not update all descendants with their new prime value");
-                        previous_id = ""; //A hack to make sure we do not process the history.previous b/c there was an error.
-                        success = false; //This is an error
-                        break; //Stop updating things, there has been an error.  This history.next[i] object cannot be considered prime.
-                    }
+                    newTreePrime(fixHistory);
                 }
                 else if(!previous_id.equals("")){ //The object being deleted had a previous.  That is now absorbed by this next object to mend the gap.  
                     fixHistory.getJSONObject("__rerum").getJSONObject("history").element("previous", previous_id);
@@ -2375,22 +2353,15 @@ public class ObjectAction extends ActionSupport implements ServletRequestAware, 
      */
      private boolean newTreePrime(JSONObject obj){
          boolean success = true;
-         try{
-            String primeID = obj.getString("@id");
-            List<DBObject> ls_versions = getAllVersions(obj);
-            JSONArray descendants = getAllDescendants(ls_versions, obj, new JSONArray());
-            for(int n=0; n< descendants.size(); n++){
-                JSONObject descendantForUpdate = descendants.getJSONObject(n);
-                JSONObject originalDescendant = descendants.getJSONObject(n);
-                BasicDBObject objToUpdate = (BasicDBObject)JSON.parse(originalDescendant.toString());;
-                descendantForUpdate.getJSONObject("__rerum").getJSONObject("history").element("prime", primeID);
-                BasicDBObject objWithUpdate = (BasicDBObject)JSON.parse(descendantForUpdate.toString());
-                mongoDBService.update(Constant.COLLECTION_ANNOTATION, objToUpdate, objWithUpdate);
-            }
-         }
-         catch(Exception e){
-             System.out.println("Could not assign new prime object @id to all descendants history.prime");
-             success = false;
+         String primeID = obj.getString("@id");
+         JSONArray descendants = new JSONArray();
+         for(int n=0; n< descendants.size(); n++){
+             JSONObject descendantForUpdate = descendants.getJSONObject(n);
+             JSONObject originalDescendant = descendants.getJSONObject(n);
+             BasicDBObject objToUpdate = (BasicDBObject)JSON.parse(originalDescendant.toString());;
+             descendantForUpdate.getJSONObject("__rerum").getJSONObject("history").element("prime", primeID);
+             BasicDBObject objWithUpdate = (BasicDBObject)JSON.parse(descendantForUpdate.toString());
+             mongoDBService.update(Constant.COLLECTION_ANNOTATION, objToUpdate, objWithUpdate);
          }
          return success;
      }
@@ -2502,7 +2473,7 @@ public class ObjectAction extends ActionSupport implements ServletRequestAware, 
         try {
             JSONObject jo = new JSONObject();
             JSONObject iiif_validation_response = checkIIIFCompliance(externalObj, true);
-            JSONObject newObjState = configureRerumOptions(externalObj, false, true);
+            JSONObject newObjState = configureRerumOptions(externalObj, true);
             DBObject dbo = (DBObject) JSON.parse(newObjState.toString());
             String exernalObjID = newObjState.getString("@id");
             String newRootID;
@@ -2513,6 +2484,8 @@ public class ObjectAction extends ActionSupport implements ServletRequestAware, 
             dboWithObjectID.append("@id", newRootID);
             newObjState.element("@id", newRootID);
             mongoDBService.update(Constant.COLLECTION_ANNOTATION, dbo, dboWithObjectID);
+            newObjState = configureRerumOptions(newObjState, false);
+            newObjState = alterHistoryPrevious(newObjState, exernalObjID); //update history.previous of the new object to contain the external object's @id.
             expandPrivateRerumProperty(newObjState);
             newObjState.remove("_id");
             jo.element("code", HttpServletResponse.SC_CREATED);
@@ -2864,4 +2837,3 @@ public class ObjectAction extends ActionSupport implements ServletRequestAware, 
     }
 
 }
-

--- a/src/java/edu/slu/action/ObjectAction.java
+++ b/src/java/edu/slu/action/ObjectAction.java
@@ -2298,10 +2298,9 @@ public class ObjectAction extends ActionSupport implements ServletRequestAware, 
                     //Strictly, all history trees must have num(root) > 0.  
                     try {
                         //Its descendants need to know this is now a root (change their prime).
-                        System.out.println("I am deleteing a root object.  Lets do newTreePrime()");
                         success = newTreePrime(fixHistory);
                         fixHistory.getJSONObject("__rerum").getJSONObject("history").element("prime", "root");
-                        fixHistory.getJSONObject("__rerum").getJSONObject("history").element("previous", ""); //The previous is deleted, so forget about it
+                        fixHistory.getJSONObject("__rerum").getJSONObject("history").element("previous", previous_id); //The previous is deleted, so forget about it
                     } catch (Exception ex) {
                         System.out.println("Could not update all descendants with their new prime value");
                         previous_id = ""; //A hack to make sure we do not process the history.previous b/c there was an error.
@@ -2366,8 +2365,7 @@ public class ObjectAction extends ActionSupport implements ServletRequestAware, 
              }
          }
          else{
-            //The history.previous is an external object.  It does not have history, the buck stops here and that's OK.
-            System.out.println("The value of history.previous was an external URI or was not present.  Nothing to heal.  URI:"+previous_id); 
+            //System.out.println("The value of history.previous was an external URI or was not present.  Nothing to heal.  URI:"+previous_id); 
          }
          return success;
      }
@@ -2379,13 +2377,10 @@ public class ObjectAction extends ActionSupport implements ServletRequestAware, 
      */
      private boolean newTreePrime(JSONObject obj){
          boolean success = true;
-         System.out.println("Make new prime(s)...");
          try{
             String primeID = obj.getString("@id");
             List<DBObject> ls_versions = getAllVersions(obj);
-            System.out.println("There are "+ls_versions.size()+" nodes in history");
             JSONArray descendants = getAllDescendants(ls_versions, obj, new JSONArray());
-            System.out.println("There are "+descendants.size()+" descendants to update.");
             for(int n=0; n< descendants.size(); n++){
                 JSONObject descendantForUpdate = descendants.getJSONObject(n);
                 JSONObject originalDescendant = descendants.getJSONObject(n);

--- a/src/java/edu/slu/common/Constant.java
+++ b/src/java/edu/slu/common/Constant.java
@@ -13,11 +13,11 @@ public class Constant {
     public static final String RERUM_API_VERSION="1.0.0";
     
     //Mongo Connection String
-    public static final String DATABASE_CONNECTION = "mongodb://rerum-dev:69Trombones@f-vl-cdh-img-01:27017/annotationStoreDev?w=majority&authMechanism=SCRAM-SHA-256";
-    //public static final String DATABASE_CONNECTION = "mongodb://rerum:Singul4rity@f-vl-cdh-img-01:27017/annotationStore?w=majority&authMechanism=SCRAM-SHA-256";
+    //public static final String DATABASE_CONNECTION = "mongodb://rerum-dev:69Trombones@f-vl-cdh-img-01:27017/annotationStoreDev?w=majority&authMechanism=SCRAM-SHA-256";
+    public static final String DATABASE_CONNECTION = "mongodb://rerum:Singul4rity@f-vl-cdh-img-01:27017/annotationStore?w=majority&authMechanism=SCRAM-SHA-256";
 
     //Mongo Database Name
-    public static final String DATABASE_NAME = "annotationStoreDev"; // NOTE this changes between dev and prod.  Check the connection string.
+    public static final String DATABASE_NAME = "annotationStore"; // NOTE this changes between dev and prod.  Check the connection string.
 
     //Database Collection Name
     public static final String COLLECTION_ANNOTATION = "alpha"; //db.alpha.doStuff()

--- a/src/java/edu/slu/common/Constant.java
+++ b/src/java/edu/slu/common/Constant.java
@@ -14,7 +14,7 @@ public class Constant {
     
     //Mongo Connection String
     public static final String DATABASE_CONNECTION = "mongodb://rerum-dev:69Trombones@f-vl-cdh-img-01:27017/annotationStoreDev?w=majority&authMechanism=SCRAM-SHA-256";
-    //"mongodb://rerum:Singul4rity@f-vl-cdh-img-01:27017/annotationStore?w=majority&authMechanism=SCRAM-SHA-256";
+    //public static final String DATABASE_CONNECTION = "mongodb://rerum:Singul4rity@f-vl-cdh-img-01:27017/annotationStore?w=majority&authMechanism=SCRAM-SHA-256";
 
     //Mongo Database Name
     public static final String DATABASE_NAME = "annotationStoreDev"; // NOTE this changes between dev and prod.  Check the connection string.
@@ -33,7 +33,7 @@ public class Constant {
     public static final String RERUM_AGENT_ClAIM="http://devstore.rerum.io/v1/agent";
 
     //RERUM API Linked Data context
-    public static final String RERUM_CONTEXT="http://devstore.rerum.io/v1/context.json";
+    public static final String RERUM_CONTEXT="http://store.rerum.io/v1/context.json";
 
     //The location of the public API documents.  This is necessary for JSON-LD context purposes.
     public static final String RERUM_API_DOC="https://github.com/CenterForDigitalHumanities/rerum_server/blob/master/API.md#__rerum";

--- a/src/java/edu/slu/common/Constant.java
+++ b/src/java/edu/slu/common/Constant.java
@@ -13,11 +13,11 @@ public class Constant {
     public static final String RERUM_API_VERSION="1.0.0";
     
     //Mongo Connection String
-    //public static final String DATABASE_CONNECTION = "mongodb://rerum-dev:69Trombones@f-vl-cdh-img-01:27017/annotationStoreDev?w=majority&authMechanism=SCRAM-SHA-256";
-    public static final String DATABASE_CONNECTION = "mongodb://rerum:Singul4rity@f-vl-cdh-img-01:27017/annotationStore?w=majority&authMechanism=SCRAM-SHA-256";
+    public static final String DATABASE_CONNECTION = "mongodb://rerum-dev:69Trombones@f-vl-cdh-img-01:27017/annotationStoreDev?w=majority&authMechanism=SCRAM-SHA-256";
+    //public static final String DATABASE_CONNECTION = "mongodb://rerum:Singul4rity@f-vl-cdh-img-01:27017/annotationStore?w=majority&authMechanism=SCRAM-SHA-256";
 
     //Mongo Database Name
-    public static final String DATABASE_NAME = "annotationStore"; // NOTE this changes between dev and prod.  Check the connection string.
+    public static final String DATABASE_NAME = "annotationStoreDev"; // NOTE this changes between dev and prod.  Check the connection string.
 
     //Database Collection Name
     public static final String COLLECTION_ANNOTATION = "alpha"; //db.alpha.doStuff()


### PR DESCRIPTION
Make sure newTreePrime does its job.  Make sure configureOptions does better with the import scenario, gotta have roots.

Let it be known this is patch.  This whole situation needs to be optimized around what is internal and external to RERUM.  Relying on `__rerum` to determine what was internal or external is flawed.  External objects can have __rerum, and we should not trust it.  Think about importing an annotationStoreDev object into annotationStore (or vice versa).  