### PR TITLE
Ong and RCG Rhetoric for store.rerum.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ documentation, but broadly, you will find:
 
 ## Who is to blame?
 
-The developers at the Walter J. Ong, <sub><sup>S.J.</sup></sub> Center for Digital Humanities authored and maintain this service.
+The developers in the Research Computing Group at Saint Louis University authored and maintain this service.
 Neither specific warranty or rights are associated with RERUM; registering and contributing implies only those rights 
 each object asserts about itself. We welcome sister instances of RERUM, ports to other languages, package managers, builds, etc.
 Contributions to this repository will be accepted as pull requests.

--- a/web/index.jsp
+++ b/web/index.jsp
@@ -119,7 +119,7 @@
             <p class="handHoldy">
                 Interacting with RERUM requires server-to-server communication, so we suggest the registrant be the application developer.  
                 You may want to 
-                <a target="_blank" href="http://centerfordigitalhumanities.github.io/rerum/web/#/future" class="linkOut">learn more about the concepts around RERUM</a> 
+                <a target="_blank" href="https://centerfordigitalhumanities.github.io/rerum/#/future" class="linkOut">learn more about the concepts around RERUM</a> 
                 before reading the API.
             </p>
             <p class="handHoldy">


### PR DESCRIPTION
Swap out or combine the mentions of Digital Humanities and Research Computing Group in page text.